### PR TITLE
default_locale のスペルミスを修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module Space
     config.generators.system_tests = nil
 
     # デフォルトを日本語に設定
-    config.i18n.defalut_locale = :ja
+    config.i18n.default_locale = :ja
 
     # タイムゾーンを日本に設定
     config.time_zone = 'Tokyo'


### PR DESCRIPTION
## #8

close #8

## 実装内容
- 日本語化設定の記述のスペルミスを修正

## 参考資料

## チェックリスト


- [ ] GitHub で Files changed を確認
- [ ] サーバーを起動して、エラーが出ないことを確認

## 備考
