### PR TITLE
ページ全体のレイアウトの設定

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,3 +14,24 @@
  *= require_self
  */
 @import "bootstrap/scss/bootstrap";
+
+/* コンテンツサイズ */
+$content-width-sm: 340px;
+$content-width-tab: 700px;
+$content-width-pc: 1200px;
+
+$breakpoints:(
+  "sm": 'screen and (max-width: 767px)',
+  "md": 'screen and (min-width: 768px)',
+) !default;
+
+@mixin mq($breakpoint: md) {
+  @media #{map-get($breakpoints, $breakpoint)}{
+    @content;
+  }
+}
+
+.base-container{
+  margin: 0 auto;
+  padding: 1rem;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,8 @@
         <%= link_to 'ログイン', new_user_session_path %>
       <% end %>
     </header>
-    <%= yield %>
+    <div class="base-container">
+      <%= yield %>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## #16
close #16

## 実装内容

- 画面レイアウトの実装
  - メディアクエリでコンテンツ幅を指定
  - ベースとなるコンテナを追加

## 参考資料

## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] サーバーを起動して、レイアウトを確認

## 備考（必要があれば）
- 暫定のため、細かい数値など、順次変更予定あり
