### PR TITLE
ショップモデルの作成

### DIFF
--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,0 +1,5 @@
+class Shop < ApplicationRecord
+  belongs_to :user
+  has_many :shop_styles, dependent: :destroy
+  has_many :styles, through: :shop_styles
+end

--- a/app/models/shop_style.rb
+++ b/app/models/shop_style.rb
@@ -1,0 +1,4 @@
+class ShopStyle < ApplicationRecord
+  belongs_to :shop
+  belongs_to :style
+end

--- a/app/models/style.rb
+++ b/app/models/style.rb
@@ -1,2 +1,4 @@
 class Style < ApplicationRecord
+  has_many :shop_styles, dependent: :destroy
+  has_many :shops, through: :shop_styles
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :shops
 end

--- a/db/migrate/20210102060922_create_shops.rb
+++ b/db/migrate/20210102060922_create_shops.rb
@@ -1,0 +1,17 @@
+class CreateShops < ActiveRecord::Migration[6.0]
+  def change
+    create_table :shops do |t|
+      t.string :shop_name, null: false, comment: "ショップ名"
+      t.time :open_time, null: false, comment: "開店時間"
+      t.time :close_time, null: false, comment: "閉店時間"
+      t.string :tel_number, null: false, :limit => 11, comment: "電話番号"
+      t.string :site_url, default: '', comment: "WEBサイトURL"
+      t.string :instgram_url, default: '', comment: "instagram URL"
+      t.text :shop_info, null: false, comment: "店舗情報"
+      t.string :sales_info, default: '', comment: "定休日・営業情報"
+      t.references :user, null: false, foreign_key: true, comment: "投稿ユーザーID"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210102072233_create_shop_styles.rb
+++ b/db/migrate/20210102072233_create_shop_styles.rb
@@ -1,0 +1,12 @@
+class CreateShopStyles < ActiveRecord::Migration[6.0]
+  def change
+    create_table :shop_styles do |t|
+      t.references :shop, null: false, foreign_key: true, index: false, comment: "ショップID"
+      t.references :style, null: false, foreign_key: true, index: false, comment: "系統マスタID"
+
+      t.timestamps
+    end
+    add_index :shop_styles, %W(shop_id style_id), unique: true
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,33 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_02_030204) do
+ActiveRecord::Schema.define(version: 2021_01_02_072233) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "shop_styles", force: :cascade do |t|
+    t.bigint "shop_id", null: false, comment: "ショップID"
+    t.bigint "style_id", null: false, comment: "系統マスタID"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["shop_id", "style_id"], name: "index_shop_styles_on_shop_id_and_style_id", unique: true
+  end
+
+  create_table "shops", force: :cascade do |t|
+    t.string "shop_name", null: false, comment: "ショップ名"
+    t.time "open_time", null: false, comment: "開店時間"
+    t.time "close_time", null: false, comment: "閉店時間"
+    t.string "tel_number", limit: 11, null: false, comment: "電話番号"
+    t.string "site_url", default: "", comment: "WEBサイトURL"
+    t.string "instgram_url", default: "", comment: "instagram URL"
+    t.text "shop_info", null: false, comment: "店舗情報"
+    t.string "sales_info", default: "", comment: "定休日・営業情報"
+    t.bigint "user_id", null: false, comment: "投稿ユーザーID"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_shops_on_user_id"
+  end
 
   create_table "styles", force: :cascade do |t|
     t.string "taste", null: false
@@ -33,4 +56,7 @@ ActiveRecord::Schema.define(version: 2021_01_02_030204) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "shop_styles", "shops"
+  add_foreign_key "shop_styles", "styles"
+  add_foreign_key "shops", "users"
 end


### PR DESCRIPTION
close #22 

## 実装内容

- ショップモデルの作成
- ショップ_スタイルモデル(中間モデル)の作成
  - 複合キーの設定

- モデル同士のアソシエーション
- `users`：`shops `⇛ 1:n
- `shops`：`shop_styles `⇛ n:n
- `styles`：`shop_styles `⇛ n:n

## 参考資料

- 複合キーの指定
[Rails 複数のカラムに 一意制約 (ユニーク)を設ける](http://yamakichi.hatenablog.com/entry/2016/08/25/003738)

- マイグレーションファイルの実行
[Railsで特定のversionのみmigrateする方法](https://qiita.com/murata0705/items/aa8455f46c8f5db26915)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] アソシエーションの確認
- [x] コンソール上で、`shop_style`モデルのレコードを作成し、一意制約エラーとなることを確認する
- [x] 影響し得る範囲のローカル環境での動作確認


## 備考
`shops`テーブルはカラム追加予定
