### PR TITLE
Feature/27 add shop brands model

### DIFF
--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,2 +1,4 @@
 class Brand < ApplicationRecord
+  has_many :shop_brands, dependent: :destroy
+  has_many :shops, through: :shop_brands
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -2,4 +2,6 @@ class Shop < ApplicationRecord
   belongs_to :user
   has_many :shop_styles, dependent: :destroy
   has_many :styles, through: :shop_styles
+  has_many :shop_brands, dependent: :destroy
+  has_many :brands, through: :shop_brands
 end

--- a/app/models/shop_brand.rb
+++ b/app/models/shop_brand.rb
@@ -1,0 +1,4 @@
+class ShopBrand < ApplicationRecord
+  belongs_to :shop
+  belongs_to :brand
+end

--- a/db/migrate/20210104104422_create_shop_brands.rb
+++ b/db/migrate/20210104104422_create_shop_brands.rb
@@ -1,0 +1,11 @@
+class CreateShopBrands < ActiveRecord::Migration[6.0]
+  def change
+    create_table :shop_brands do |t|
+      t.references :shop, null: false, foreign_key: true, index: false, comment: "ショップID"
+      t.references :brand, null: false, foreign_key: true, index: false, comment: "ブランドID"
+
+      t.timestamps
+    end
+    add_index :shop_brands, %W(shop_id brand_id), unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_04_101036) do
+ActiveRecord::Schema.define(version: 2021_01_04_104422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,14 @@ ActiveRecord::Schema.define(version: 2021_01_04_101036) do
     t.string "brand_name_kana", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "shop_brands", force: :cascade do |t|
+    t.bigint "shop_id", null: false, comment: "ショップID"
+    t.bigint "brand_id", null: false, comment: "ブランドID"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["shop_id", "brand_id"], name: "index_shop_brands_on_shop_id_and_brand_id", unique: true
   end
 
   create_table "shop_styles", force: :cascade do |t|
@@ -63,6 +71,8 @@ ActiveRecord::Schema.define(version: 2021_01_04_101036) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "shop_brands", "brands"
+  add_foreign_key "shop_brands", "shops"
   add_foreign_key "shop_styles", "shops"
   add_foreign_key "shop_styles", "styles"
   add_foreign_key "shops", "users"


### PR DESCRIPTION
## #27 

close #27 

## 実装内容
- `brands`モデルの作成
- `shops` モデルと `brands` モデルの中間テーブルを作成
  - 以下の外部キーで複合キーを指定
  - `shop_id`と `brand_id`
- 関連付け
- shopモデル
- brandモデル

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 備考
