### PR TITLE
ショップ画像モデルの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'devise'
 gem 'devise-i18n'
 gem 'devise-bootstrap-views'
 gem 'activeadmin'
-
+gem 'carrierwave'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arbre (1.4.0)
       activesupport (>= 3.0.0, < 6.2)
       ruby2_keywords (>= 0.0.2, < 1.0)
@@ -74,6 +76,13 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    carrierwave (2.1.0)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
@@ -102,6 +111,9 @@ GEM
       activesupport (>= 4.1)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     inherited_resources (1.12.0)
       actionpack (>= 5.2, < 6.2)
       has_scope (~> 0.6)
@@ -137,6 +149,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.5)
+    mini_magick (4.11.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -152,6 +165,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    public_suffix (4.0.6)
     puma (4.3.7)
       nio4r (~> 2.0)
     rack (2.2.3)
@@ -196,6 +210,8 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby2_keywords (0.0.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -249,6 +265,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  carrierwave
   devise
   devise-bootstrap-views
   devise-i18n

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,5 +1,6 @@
 class Shop < ApplicationRecord
   belongs_to :user
+  has_many :shop_images
   has_many :shop_styles, dependent: :destroy
   has_many :styles, through: :shop_styles
   has_many :shop_brands, dependent: :destroy

--- a/app/models/shop_image.rb
+++ b/app/models/shop_image.rb
@@ -1,0 +1,4 @@
+class ShopImage < ApplicationRecord
+  mount_uploaders :images, ImageUploader
+  belongs_to :shops
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,47 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/db/migrate/20210107140129_create_shop_images.rb
+++ b/db/migrate/20210107140129_create_shop_images.rb
@@ -1,0 +1,10 @@
+class CreateShopImages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :shop_images do |t|
+      t.json :images, null: false, comment: "ショップ画像"
+      t.references :shop, null: false, foreign_key: true, comment: "ショップID"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_06_050725) do
+ActiveRecord::Schema.define(version: 2021_01_07_140129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,14 @@ ActiveRecord::Schema.define(version: 2021_01_06_050725) do
     t.index ["shop_id", "brand_id"], name: "index_shop_brands_on_shop_id_and_brand_id", unique: true
   end
 
+  create_table "shop_images", force: :cascade do |t|
+    t.json "images", null: false, comment: "ショップ画像"
+    t.bigint "shop_id", null: false, comment: "ショップID"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["shop_id"], name: "index_shop_images_on_shop_id"
+  end
+
   create_table "shop_styles", force: :cascade do |t|
     t.bigint "shop_id", null: false, comment: "ショップID"
     t.bigint "style_id", null: false, comment: "系統マスタID"
@@ -99,6 +107,7 @@ ActiveRecord::Schema.define(version: 2021_01_06_050725) do
 
   add_foreign_key "shop_brands", "brands"
   add_foreign_key "shop_brands", "shops"
+  add_foreign_key "shop_images", "shops"
   add_foreign_key "shop_styles", "shops"
   add_foreign_key "shop_styles", "styles"
   add_foreign_key "shops", "users"


### PR DESCRIPTION
close #31 

## 実装内容

- ショップサムネイルモデルの作成
  - `shops`モデルと1:nの関係で関連付け
- 画像アップロード用 gem `CarrierWave`の導入
  - `shop_images`モデルにアップローダーメソッドをマウント

### 設計書
[DB(テーブル)_詳細設計書 Shop_imagesモデル](https://docs.google.com/spreadsheets/d/1a0YhdVtr8mX5blABDtOSthhT1XV3JU4XNchhfDeQoT0/edit#gid=1935319169)
[ER図](https://app.diagrams.net/?libs=general;uml;er#G1o0Ltp0zt0hPl40SwBZfcYDru5kjX2tul)

## 参考資料
- 画像アップロード機能
  - [CarrierWave 公式](https://github.com/carrierwaveuploader/carrierwave)

## チェックリスト
- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## 備考