### PR TITLE
ショップモデルの登録処理を実装

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -2,4 +2,33 @@ class ShopsController < ApplicationController
   before_action :authenticate_user!
   def index
   end
+
+  def new
+    @shop = ShopRegistrationForm.new
+    @shop.user_id =  current_user.id
+  end
+
+  def create
+    @shop = ShopRegistrationForm.new(shop_params)
+    if @shop.save
+      flash[:notice] = "新たにショップを登録しました"
+      redirect_to root_path
+    else
+      render new
+    end
+  end
+
+  private
+  def shop_params
+    params.require(:shop_registration_form).permit( :shop_name,
+                                                    :open_time,
+                                                    :close_time,
+                                                    :tel_number,
+                                                    :site_url,
+                                                    :instgram_url,
+                                                    :shop_info,
+                                                    :sales_info,
+                                                    :user_id
+                                                  )
+  end
 end

--- a/app/forms/shop_registration_form.rb
+++ b/app/forms/shop_registration_form.rb
@@ -1,0 +1,31 @@
+class ShopRegistrationForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :shop_name, :string
+  attribute :open_time, :time
+  attribute :close_time, :time
+  attribute :tel_number, :string
+  attribute :site_url, :string
+  attribute :instgram_url, :string
+  attribute :shop_info, :string
+  attribute :sales_info, :string
+  attribute :user_id, :big_integer
+
+  def save
+    shop.save!
+  end
+
+  private
+  def shop
+    Shop.create( shop_name: shop_name, 
+                  open_time: open_time,
+                  close_time: close_time,
+                  tel_number: tel_number, 
+                  site_url: site_url,
+                  instgram_url: instgram_url,
+                  shop_info: shop_info,
+                  user_id: user_id
+                )
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
     <header>
       <% if user_signed_in? %>
         <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: {confirm: 'ログアウトしますか？'} %>
+        <%= link_to 'ショップ登録', new_user_shop_path(current_user.id) %>
       <% else %>
         <%= link_to '新規登録', new_user_registration_path %>
         <%= link_to 'ログイン', new_user_session_path %>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -1,1 +1,4 @@
+  <% if flash[:notice] %>
+    <div class="notice"><%= flash[:notice] %></div>
+  <% end %>
 <h1 class="text-center">TOP PAGE</h1>

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -1,4 +1,4 @@
-  <% if flash[:notice] %>
-    <div class="notice"><%= flash[:notice] %></div>
-  <% end %>
+<% if flash[:notice] %>
+  <div class="notice"><%= flash[:notice] %></div>
+<% end %>
 <h1 class="text-center">TOP PAGE</h1>

--- a/app/views/shops/new.html.erb
+++ b/app/views/shops/new.html.erb
@@ -1,0 +1,36 @@
+<%= form_with model: @shop, url: user_shops_path, local: true do |f| %>
+  <div class="form-group">
+    <p><%= f.label :shop_name %></p>
+    <%= f.text_field :shop_name, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <p><%= f.label :open_time %></p>
+    <%= f.time_field :open_time, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <p><%= f.label :close_time %></p>
+    <%= f.time_field :close_time, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <p><%= f.label :tel_number %></p>
+    <%= f.text_field :tel_number, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <p><%= f.label :site_url %></p>
+    <%= f.text_field :site_url, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <p><%= f.label :instgram_url %></p>
+    <%= f.text_field :instgram_url, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <p><%= f.label :sales_info %></p>
+    <%= f.text_field :sales_info, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <p><%= f.label :shop_info %></p>
+    <%= f.text_area :shop_info, class: "form-control" %>
+  </div>
+  <%= f.hidden_field :user_id %>
+  <%= f.submit class: "btn btn-primary" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,7 @@ Rails.application.routes.draw do
   devise_for :users
   # トップページ
   root to: 'shops#index'
+  resources :users, only: %W() do
+    resources :shops
+  end
 end


### PR DESCRIPTION
close #33 

## 実装内容

- ルーティングの変更
  - `users`モデルと`shops`モデルのルーティングをネスト
- 登録処理の実装(ショップモデルのみ)
  - `new`、`create`アクションの実装
- フォームオブジェクトの導入
  - 登録処理のロジックを実装
- ビューの編集
  - 登録フォームの追加
  - ショップ一覧画面に登録成功時のフラッシュメッセージを追加
  - ヘッダーにショップ登録画面へのリンクを追加

## 参考資料
- フォームオブジェクト
  - [パーフェクト Ruby on Rails 【増補改訂版】](https://www.amazon.co.jp/%E3%83%91%E3%83%BC%E3%83%95%E3%82%A7%E3%82%AF%E3%83%88-Ruby-Rails-%E3%80%90%E5%A2%97%E8%A3%9C%E6%94%B9%E8%A8%82%E7%89%88%E3%80%91-Perfect/dp/4297114623/ref=sr_1_1?__mk_ja_JP=%E3%82%AB%E3%82%BF%E3%82%AB%E3%83%8A&dchild=1&keywords=%E3%83%91%E3%83%BC%E3%83%95%E3%82%A7%E3%82%AF%E3%83%88ruby&qid=1610252381&sr=8-1)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 画面からショップ情報を登録出来ることを確認
- [x] 影響し得る範囲のローカル環境での動作確認
