### PR TITLE
ショップモデル登録時バリデーションの設定

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -14,7 +14,7 @@ class ShopsController < ApplicationController
       flash[:notice] = "新たにショップを登録しました"
       redirect_to root_path
     else
-      render new
+      render 'new'
     end
   end
 

--- a/app/forms/shop_registration_form.rb
+++ b/app/forms/shop_registration_form.rb
@@ -1,24 +1,48 @@
 class ShopRegistrationForm
   include ActiveModel::Model
-  include ActiveModel::Attributes
 
-  attribute :shop_name, :string
-  attribute :open_time, :time
-  attribute :close_time, :time
-  attribute :tel_number, :string
-  attribute :site_url, :string
-  attribute :instgram_url, :string
-  attribute :shop_info, :string
-  attribute :sales_info, :string
-  attribute :user_id, :big_integer
+  attr_accessor :shop_name,
+                :open_time,
+                :close_time,
+                :tel_number,
+                :site_url,
+                :instgram_url,
+                :shop_info,
+                :sales_info,
+                :user_id
+
+  def initialize(shop_params = {})
+    @shop_name = shop_params[:shop_name]
+    @open_time = shop_params[:open_time]
+    @close_time = shop_params[:close_time]
+    @tel_number = shop_params[:tel_number]
+    @instgram_url = shop_params[:instgram_url]
+    @site_url = shop_params[:site_url]
+    @shop_info = shop_params[:shop_info]
+    @sales_info = shop_params[:sales_info]
+    @user_id = shop_params[:user_id]
+  end
+
+  validates :shop_name, presence: true
+  validates :shop_name, length: {maximum: 100}, if: Proc.new{|shop|shop.shop_name.present?}  #最大文字数
+
+  validates :open_time, :close_time, :tel_number, :user_id, presence: true  #空チェック
+
+  validates :tel_number, length: {maximum: 11}, format: {with: /\A[0-9]+\z/, message: "は数字で入力して下さい"},if: Proc.new{|shop|shop.tel_number.present?} #最大文字数, フォーマット
+
+  validates :shop_info, presence: true
+  validates :shop_info, length: {maximum: 500}, if: Proc.new{|shop|shop.shop_info.present?}  #最大文字数
+
+  validates :sales_info, length: {maximum: 50}, if: Proc.new{|shop|shop.sales_info.present?} #最大文字数
 
   def save
+    return false if invalid?
     shop.save!
   end
 
   private
   def shop
-    Shop.create( shop_name: shop_name, 
+    shop = Shop.new( shop_name: shop_name,
                   open_time: open_time,
                   close_time: close_time,
                   tel_number: tel_number, 

--- a/app/views/shops/new.html.erb
+++ b/app/views/shops/new.html.erb
@@ -1,3 +1,14 @@
+<!-- エラーメッセージ -->
+<% if @shop.errors.any? %>
+    <div class = "alert alert-warning">
+        <ul>
+            <% @shop.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+            <% end %>
+        </ul>
+    </div>
+<% end %>
+
 <%= form_with model: @shop, url: user_shops_path, local: true do |f| %>
   <div class="form-group">
     <p><%= f.label :shop_name %></p>
@@ -5,11 +16,11 @@
   </div>
   <div class="form-group">
     <p><%= f.label :open_time %></p>
-    <%= f.time_field :open_time, class: "form-control" %>
+    <%= f.time_field :open_time, value: @shop.open_time, class: "form-control" %>
   </div>
   <div class="form-group">
     <p><%= f.label :close_time %></p>
-    <%= f.time_field :close_time, class: "form-control" %>
+    <%= f.time_field :close_time, value: @shop.close_time, class: "form-control" %>
   </div>
   <div class="form-group">
     <p><%= f.label :tel_number %></p>


### PR DESCRIPTION
close #35 

## 実装内容

- バリデーションの設定
  - `form object`にバリデーションを設定
- `form object`でのカラムの管理を`ActiveModel::Attributes`から`attr_accsessor`へ変更
- 登録失敗時にエラーメッセージを出力させる。
- 登録失敗時に`render`で入力値が保持されるように、`time_filed`に`value`オプションを設定
- 設定したバリデーションがエラーになることを確認する。

## 参考資料
- `time_field`の入力値保持
[stack overflow](https://stackoverflow.com/questions/52620740/default-value-in-time-field-in-rails-5)
- フォームオブジェクトの実装
[https://tech.medpeer.co.jp/entry/2017/05/09/070758]

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] バリデーションが実行されることを確認

## 備考
`form object`の実装は順次変更していく