### PR TITLE
ショップ画像テーブルの定義を修正

### DIFF
--- a/app/models/shop_image.rb
+++ b/app/models/shop_image.rb
@@ -1,4 +1,4 @@
 class ShopImage < ApplicationRecord
-  mount_uploaders :images, ImageUploader
-  belongs_to :shops
+  mount_uploader :image, ImageUploader
+  belongs_to :shop
 end

--- a/db/migrate/20210107140129_create_shop_images.rb
+++ b/db/migrate/20210107140129_create_shop_images.rb
@@ -1,7 +1,7 @@
 class CreateShopImages < ActiveRecord::Migration[6.0]
   def change
     create_table :shop_images do |t|
-      t.json :images, null: false, comment: "ショップ画像"
+      t.string :image, null: false, comment: "ショップ画像"
       t.references :shop, null: false, foreign_key: true, comment: "ショップID"
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 2021_01_07_140129) do
   end
 
   create_table "shop_images", force: :cascade do |t|
-    t.json "images", null: false, comment: "ショップ画像"
+    t.string "image", null: false, comment: "ショップ画像"
     t.bigint "shop_id", null: false, comment: "ショップID"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
close #44 

## 実装内容

- `shop_images`モデルの`images`カラムを以下の用に変更
  - カラム名を `images`から `image`に変更
  - 型を`json`から `string`に変更
- カラムの定義変更により`carrierwave`のマウント部分を変更

## チェックリスト
- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認