### PR TITLE
ショップモデルの登録処理のレイヤーを変更

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -4,14 +4,14 @@ class ShopsController < ApplicationController
   end
 
   def new
-    @shop = ShopRegistrationForm.new
+    @shop = Shop.new
     @shop.user_id =  current_user.id
   end
 
   def create
-    @shop = ShopRegistrationForm.new(shop_params)
+    @shop = Shop.new(shop_params)
     if @shop.save
-      flash[:notice] = "新たにショップを登録しました"
+      flash[:success] = "新たにショップを登録しました"
       redirect_to root_path
     else
       render 'new'
@@ -20,16 +20,16 @@ class ShopsController < ApplicationController
 
   private
   def shop_params
-    params.require(:shop_registration_form).permit( :shop_name,
-                                                    :open_time,
-                                                    :close_time,
-                                                    :tel_number,
-                                                    :site_url,
-                                                    :instgram_url,
-                                                    :shop_info,
-                                                    :sales_info,
-                                                    :user_id,
-                                                    shop_style_ids: []
-                                                  )
+    params.require(:shop).permit(
+                                  :shop_name,
+                                  :open_time,
+                                  :close_time,
+                                  :tel_number,
+                                  :site_url,
+                                  :instgram_url,
+                                  :shop_info,
+                                  :sales_info,
+                                  :user_id
+                                )
   end
 end

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -1,4 +1,4 @@
-<% if flash[:notice] %>
-  <div class="notice"><%= flash[:notice] %></div>
+<% if flash[:success] %>
+  <div class="notice"><%= flash[:success] %></div>
 <% end %>
 <h1 class="text-center">TOP PAGE</h1>

--- a/app/views/shops/new.html.erb
+++ b/app/views/shops/new.html.erb
@@ -16,11 +16,11 @@
   </div>
   <div class="form-group">
     <p><%= f.label :open_time %></p>
-    <%= f.time_field :open_time, value: @shop.open_time, class: "form-control" %>
+    <%= f.time_field :open_time, class: "form-control" %>
   </div>
   <div class="form-group">
     <p><%= f.label :close_time %></p>
-    <%= f.time_field :close_time, value: @shop.close_time, class: "form-control" %>
+    <%= f.time_field :close_time, class: "form-control" %>
   </div>
   <div class="form-group">
     <p><%= f.label :tel_number %></p>
@@ -41,12 +41,6 @@
   <div class="form-group">
     <p><%= f.label :shop_info %></p>
     <%= f.text_area :shop_info, class: "form-control" %>
-  </div>
-  <div class="form-check">
-    <%= f.collection_check_boxes :shop_style_ids, Style.all, :id, :taste, checked: @shop.shop_style_ids ,include_hidden: false do |b| %>
-      <%= b.check_box %>
-      <%= b.text %>
-    <% end %>
   </div>
   <%= f.hidden_field :user_id %>
   <%= f.submit class: "btn btn-primary" %>


### PR DESCRIPTION
close #48 

## 実装内容

- ショップモデルの登録処理を`form object`から`model`層に変更
  - ショップコントローラーでインスタンス化を`form object`から`shop`モデルに変更
  - `nre.html.erb`から、`ショップスタイル`のフィールドを一旦削除

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認