### PR TITLE
取り扱いカラムを追加

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -25,6 +25,7 @@ class ShopsController < ApplicationController
                                   :open_time,
                                   :close_time,
                                   :tel_number,
+                                  :treatment,
                                   :site_url,
                                   :instgram_url,
                                   :shop_info,

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -5,4 +5,6 @@ class Shop < ApplicationRecord
   has_many :styles, through: :shop_styles
   has_many :shop_brands, dependent: :destroy
   has_many :brands, through: :shop_brands
+
+  enum treatment: {male: 0, female: 1, unisex: 2}
 end

--- a/app/views/shops/new.html.erb
+++ b/app/views/shops/new.html.erb
@@ -27,6 +27,10 @@
     <%= f.text_field :tel_number, class: "form-control" %>
   </div>
   <div class="form-group">
+    <p><%= f.label :treatment %></p>
+    <%= f.select :treatment, Shop.treatments.keys, {prompt: "選択してください"}, class: "form-control" %>
+  </div>
+  <div class="form-group">
     <p><%= f.label :site_url %></p>
     <%= f.text_field :site_url, class: "form-control" %>
   </div>

--- a/db/migrate/20210121120951_add_treatment_to_shops.rb
+++ b/db/migrate/20210121120951_add_treatment_to_shops.rb
@@ -1,0 +1,5 @@
+class AddTreatmentToShops < ActiveRecord::Migration[6.0]
+  def change
+    add_column :shops, :treatment, :integer, null: false, comment: "取り扱い"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_07_140129) do
+ActiveRecord::Schema.define(version: 2021_01_21_120951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2021_01_07_140129) do
     t.bigint "user_id", null: false, comment: "投稿ユーザーID"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "treatment", null: false, comment: "取り扱い"
     t.index ["user_id"], name: "index_shops_on_user_id"
   end
 


### PR DESCRIPTION
close #50 

## 実装内容

- ショップモデルに `取り扱いカラム`を追加
  - マイグレーションファイルの作成と`db:migrate`の実行
  - コントローラーにストロングパラメータを追加
  - ビューファイルにセレクトボックスを追加

## 参考資料
- 
  - [【Rails】enumを使用したセレクトボックスの実装とDBへの保存 ](https://qiita.com/y-suna/items/1f5f34c6289fd88199a5)

## チェックリスト


- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 備考
`enum`の表示を日本語化する
