### PR TITLE
enumの日本語化処理の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'devise-i18n'
 gem 'devise-bootstrap-views'
 gem 'activeadmin'
 gem 'carrierwave'
+gem 'enum_help'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     ffi (1.14.2)
     formtastic (3.1.5)
@@ -270,6 +272,7 @@ DEPENDENCIES
   devise-bootstrap-views
   devise-i18n
   dotenv-rails
+  enum_help
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/views/shops/new.html.erb
+++ b/app/views/shops/new.html.erb
@@ -28,7 +28,7 @@
   </div>
   <div class="form-group">
     <p><%= f.label :treatment %></p>
-    <%= f.select :treatment, Shop.treatments.keys, {prompt: "選択してください"}, class: "form-control" %>
+    <%= f.select :treatment, Shop.treatments.keys.map{|k| [I18n.t("enums.shop.treatment.#{k}"), k]}, {prompt: "選択してください"}, class: "form-control" %>
   </div>
   <div class="form-group">
     <p><%= f.label :site_url %></p>

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -7,12 +7,19 @@ ja:
         shop_name: ショップ名
         open_time: 開店時間
         close_time: 閉店時間
+        treatment: 取り扱い
         tel_number: 電話番号
         site_url: WebサイトURL
         instgram_url: Instgram URL
         sales_info: 定休日・営業情報等
         shop_info: オススメポイント
         shop_style_ids: ショップの系統
+  enums:
+    shop:
+      treatment:
+        male: メンズ
+        female: レディース
+        unisex: メンズ・レディース
   activemodel:
     attributes: 
       shop_registration_form:


### PR DESCRIPTION
close #52 

## 実装内容

- gem enum-helpの導入
- ymlファイルに定義を追加
- viewファイルに日本語を出力するように処理を追加

## 参考資料

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット


## 備考
