### PR TITLE
バリデーションをform objectからモデルへ移行

### DIFF
--- a/app/forms/shop_registration_form.rb
+++ b/app/forms/shop_registration_form.rb
@@ -25,20 +25,6 @@ class ShopRegistrationForm
     @shop_style_ids = shop_params[:shop_style_ids]
   end
 
-  validates :shop_name, presence: true
-  validates :shop_name, length: {maximum: 100}, if: Proc.new{|shop|shop.shop_name.present?}  #最大文字数
-
-  validates :open_time, :close_time, :tel_number, :user_id, presence: true  #空チェック
-
-  validates :tel_number, length: {maximum: 11}, format: {with: /\A[0-9]+\z/, message: "は数字で入力して下さい"},if: Proc.new{|shop|shop.tel_number.present?} #最大文字数, フォーマット
-
-  validates :shop_info, presence: true
-  validates :shop_info, length: {maximum: 500}, if: Proc.new{|shop|shop.shop_info.present?}  #最大文字数
-
-  validates :sales_info, length: {maximum: 50}, if: Proc.new{|shop|shop.sales_info.present?} #最大文字数
-
-  validates :shop_style_ids, presence: {message: :not_select}
-
   def save
     return false if invalid?
     shop.save!

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -7,4 +7,14 @@ class Shop < ApplicationRecord
   has_many :brands, through: :shop_brands
 
   enum treatment: {male: 0, female: 1, unisex: 2}
+
+  # バリデーション
+  validates :shop_name, presence: true
+  validates :shop_name, length: {maximum: 100}, if: Proc.new{|shop|shop.shop_name.present?}
+  validates :open_time, :close_time, :tel_number, :user_id, presence: true
+  validates :tel_number, length: {maximum: 11}, format: {with: /\A[0-9]+\z/, message: :not_a_number},if: Proc.new{|shop|shop.tel_number.present?}
+  validates :treatment, presence: {message: :not_select}
+  validates :sales_info, length: {maximum: 50}, if: Proc.new{|shop|shop.sales_info.present?}
+  validates :shop_info, presence: true
+  validates :shop_info, length: {maximum: 500}, if: Proc.new{|shop|shop.shop_info.present?}
 end


### PR DESCRIPTION
close #54 

## 実装内容

- shopモデルのバリデーションをform objectからmodelレイヤーへ移行  
- `treatment`カラムの必須チェックを追加

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認