### PR TITLE
ショップスタイルモデルの登録処理追加

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -5,10 +5,12 @@ class ShopsController < ApplicationController
 
   def new
     @shop = Shop.new
+    @shop.shop_styles.build
     @shop.user_id =  current_user.id
   end
 
   def create
+    binding.pry
     @shop = Shop.new(shop_params)
     if @shop.save
       flash[:success] = "新たにショップを登録しました"
@@ -30,7 +32,8 @@ class ShopsController < ApplicationController
                                   :instgram_url,
                                   :shop_info,
                                   :sales_info,
-                                  :user_id
+                                  :user_id,
+                                  style_ids:[]
                                 )
   end
 end

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -10,7 +10,6 @@ class ShopsController < ApplicationController
   end
 
   def create
-    binding.pry
     @shop = Shop.new(shop_params)
     if @shop.save
       flash[:success] = "新たにショップを登録しました"

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,12 +1,14 @@
 class Shop < ApplicationRecord
   belongs_to :user
   has_many :shop_images
-  has_many :shop_styles, dependent: :destroy
+  has_many :shop_styles, dependent: :destroy, validate: true, inverse_of: :shop
   has_many :styles, through: :shop_styles
   has_many :shop_brands, dependent: :destroy
   has_many :brands, through: :shop_brands
 
   enum treatment: {male: 0, female: 1, unisex: 2}
+
+  accepts_nested_attributes_for :shop_styles, allow_destroy: true
 
   # バリデーション
   validates :shop_name, presence: true
@@ -17,4 +19,8 @@ class Shop < ApplicationRecord
   validates :sales_info, length: {maximum: 50}, if: Proc.new{|shop|shop.sales_info.present?}
   validates :shop_info, presence: true
   validates :shop_info, length: {maximum: 500}, if: Proc.new{|shop|shop.shop_info.present?}
+  validates :style_ids, presence: {message: :not_select}
+
+  # 関連付け先バリデーション
+  validates_associated :shop_styles
 end

--- a/app/models/shop_style.rb
+++ b/app/models/shop_style.rb
@@ -1,4 +1,8 @@
 class ShopStyle < ApplicationRecord
   belongs_to :shop
   belongs_to :style
+
+  # バリデーション
+  validates :shop, presence: true
+  validates :style_id, uniqueness: {scope: :shop_id}
 end

--- a/app/views/shops/new.html.erb
+++ b/app/views/shops/new.html.erb
@@ -46,6 +46,12 @@
     <p><%= f.label :shop_info %></p>
     <%= f.text_area :shop_info, class: "form-control" %>
   </div>
+
+  <%= f.collection_check_boxes :style_ids, Style.all, :id, :taste, checked: @shop.style_ids ,include_hidden: false do |b| %>
+    <%= b.check_box %>
+    <%= b.text %>
+  <% end %>
+
   <%= f.hidden_field :user_id %>
   <%= f.submit class: "btn btn-primary" %>
 <% end %>

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -13,7 +13,7 @@ ja:
         instgram_url: Instgram URL
         sales_info: 定休日・営業情報等
         shop_info: オススメポイント
-        shop_style_ids: ショップの系統
+        style_ids: ショップの系統
   enums:
     shop:
       treatment:
@@ -31,4 +31,4 @@ ja:
         instgram_url: Instgram URL
         sales_info: 定休日・営業情報等
         shop_info: オススメポイント
-        shop_style_ids: ショップの系統
+        style_ids: ショップの系統


### PR DESCRIPTION
close #56

## 実装内容

- ショップスタイルモデルの登録処理追加
  - ストロングパラメータを追加(配列で受け取れる形式)
  - ビューファイルにフィールドを追加 (`collection_check_boxes` を採用)
- バリデーションの設定
  - ショップモデル
    - ショップモデルに必須選択のバリデーションを設定
    - ショップモデルに関連付け先のモデルのバリデーションを実行するような処理を追加

    - ショップスタイルモデル
    -  `shop_id`と`style_id`に一意制約チェックを追加
    - 外部キー(`shop_id`)に対して、空チェックを追加

## 参考資料
- バリデーション 
  - 外部キーの空チェック
    - [Quita 関連付け先のバリデーション対象項目が親オブジェクトのIDの場合](https://qiita.com/kozo002/items/73e6c17d9a3778fba641)
    - 一意制約
    - [Rails ガイド uniqueness](https://railsguides.jp/active_record_validations.html#uniqueness)
- 関連付けのオプション
  - [Railsガイド Active Record の関連付け](https://railsguides.jp/association_basics.html#belongs-to%E3%81%AE%E3%82%AA%E3%83%97%E3%82%B7%E3%83%A7%E3%83%B3-validate)  
## チェックリスト


- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット


## 備考
