### PR TITLE
Feature/58 registration shop images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 
 /public/assets
 .byebug_history
+/public/uploads/*
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
@@ -37,3 +38,4 @@ yarn-debug.log*
 
 
 /.env
+.Ds_Store

--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -6,6 +6,7 @@ class ShopsController < ApplicationController
   def new
     @shop = Shop.new
     @shop.shop_styles.build
+    2.times{@shop.shop_images.build}
     @shop.user_id =  current_user.id
   end
 
@@ -32,6 +33,7 @@ class ShopsController < ApplicationController
                                   :shop_info,
                                   :sales_info,
                                   :user_id,
+                                  shop_images_attributes: [:id, :image, :image_cache],
                                   style_ids:[]
                                 )
   end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -9,6 +9,7 @@ class Shop < ApplicationRecord
   enum treatment: {male: 0, female: 1, unisex: 2}
 
   accepts_nested_attributes_for :shop_styles, allow_destroy: true
+  accepts_nested_attributes_for :shop_images, allow_destroy: true
 
   # バリデーション
   validates :shop_name, presence: true

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -46,6 +46,6 @@ class ImageUploader < CarrierWave::Uploader::Base
   # end
 
   def size_range
-    0..1.megabytes
+    0..5.megabytes
   end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -35,13 +35,17 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_whitelist
+    %w(jpg jpeg gif png)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
   # def filename
   #   "something.jpg" if original_filename
   # end
+
+  def size_range
+    0..1.megabytes
+  end
 end

--- a/app/views/shops/new.html.erb
+++ b/app/views/shops/new.html.erb
@@ -52,6 +52,18 @@
     <%= b.text %>
   <% end %>
 
+  <% if @shop.shop_images.size > 0 %>
+    <% @shop.shop_images.each do |shop_image| %>
+      <%= image_tag(shop_image.image.url) if shop_image.image? %>
+    <% end %>
+  <% end %>
+  <%= f.fields_for :shop_images do |ff| %>
+    <div class="form-group">
+      <%= ff.file_field :image %>
+      <%= ff.hidden_field :image_cache %>
+    </div>
+  <% end %>
+
   <%= f.hidden_field :user_id %>
   <%= f.submit class: "btn btn-primary" %>
 <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -134,6 +134,17 @@ ja:
       too_short: は%{count}文字以上で入力してください
       wrong_length: は%{count}文字で入力してください
       not_select: を選択してください
+      carrierwave_processing_error: 処理できませんでした
+      carrierwave_integrity_error: は許可されていないファイルタイプです
+      carrierwave_download_error: はダウンロードできません
+      extension_whitelist_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできるファイルタイプ: %{allowed_types}"
+      extension_blacklist_error: "%{extension}ファイルのアップロードは許可されていません。アップロードできないファイルタイプ: %{prohibited_types}"
+      content_type_whitelist_error: "%{content_type}ファイルのアップロードは許可されていません"
+      content_type_blacklist_error: "%{content_type}ファイルのアップロードは許可されていません"
+      rmagick_processing_error: "rmagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+      mini_magick_processing_error: "MiniMagickがファイルを処理できませんでした。画像を確認してください。エラーメッセージ: %{e}"
+      min_size_error: "ファイルを%{min_size}バイト以上のサイズにしてください"
+      max_size_error: "ファイルを%{max_size}バイト以下のサイズにしてください"
     template:
       body: 次の項目を確認してください
       header:

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord:
     models:
       shop: ショップ
+      shop_images: ショップ画像
     attributes:
       shop:
         shop_name: ショップ名
@@ -14,6 +15,8 @@ ja:
         sales_info: 定休日・営業情報等
         shop_info: オススメポイント
         style_ids: ショップの系統
+      shop/shop_images:
+        image: ショップの画像
   enums:
     shop:
       treatment:


### PR DESCRIPTION
## issue 番号（必須）

close #

## 実装内容

- ショップ画像モデルの登録処理を実装
  - ショップモデルと同一フォームから登録可能にする
    - accepts_nested_attributes_forの設定
  - コントローラ
    - ショップモデルのインスタンス作成時に画像モデルも登録出来る用に処理を追加
    - ストロングパラメータを追加
  - ビュー
    - 画像投稿出来るようにフィールドを追加
      - 複数投稿出来るようにfields_forを使用する
  - バリデーション
    - carrierwaveのバリデーションを有効化する
      - 拡張子の制限
    - 容量の制限(5MB)
  - ymlファイル
    - 画像カラムの翻訳を追加
    - `carrierwave`のエラーメッセージを追加
  - 登録した画像ファイルをgit管理配下から除外する
    - .gitignoreに対象のパスを追加

## 参考資料
- ymlファイルの`i18n`へ対応
  - [accepts_nested_attributes_forしたときのi18n](https://nisshiee.hatenablog.jp/entry/2017/05/09/195115)
  - [rails github公式](https://github.com/rails/rails/blob/v5.0.2/activemodel/lib/active_model/translation.rb#L43)
- `carrierwave `エラーメッセージ
  - [carrierwave Read.me](https://github.com/carrierwaveuploader/carrierwave#i18n)
- 画像のサイズ制限
  - [carrierwave github](https://github.com/carrierwaveuploader/carrierwave/blob/master/lib/carrierwave/uploader/file_size.rb#L25)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット


## 備考
