### PR TITLE
取り扱いブランドの登録処理を追加

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -6,6 +6,7 @@ class ShopsController < ApplicationController
   def new
     @shop = Shop.new
     @shop.shop_styles.build
+    @shop.shop_brands.build
     2.times{@shop.shop_images.build}
     @shop.user_id =  current_user.id
   end
@@ -34,7 +35,8 @@ class ShopsController < ApplicationController
                                   :sales_info,
                                   :user_id,
                                   shop_images_attributes: [:id, :image, :image_cache],
-                                  style_ids:[]
+                                  style_ids:[],
+                                  brand_ids: []
                                 )
   end
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -10,6 +10,7 @@ class Shop < ApplicationRecord
 
   accepts_nested_attributes_for :shop_styles, allow_destroy: true
   accepts_nested_attributes_for :shop_images, allow_destroy: true
+  accepts_nested_attributes_for :shop_brands, allow_destroy: true
 
   # バリデーション
   validates :shop_name, presence: true

--- a/app/views/shops/new.html.erb
+++ b/app/views/shops/new.html.erb
@@ -51,6 +51,12 @@
     <%= b.check_box %>
     <%= b.text %>
   <% end %>
+  <div class="form-group">
+    <p><%= f.label :brand_ids %></p>
+    <%= f.collection_check_boxes :brand_ids, Brand.all, :id, :brand_name, checked: @shop.brand_ids ,include_hidden: false do |b| %>
+      <% b.label {b.check_box(data: {brand_id: b.object.id}) + b.text + b.object.brand_name_kana} %>
+    <% end %>
+  </div>
 
   <% if @shop.shop_images.size > 0 %>
     <% @shop.shop_images.each do |shop_image| %>


### PR DESCRIPTION
close #60 

## 実装内容

- モデル
  - ショップ登録時に同一フォームから登録
    - ショップモデルに`accepts_nested_attributes_for`を設定
- コントローラ
  - ストロングパラメータを追加
  - `new`アクションで`build`する
- ビュー
  - フィールドの追加(`collection_check_boxes`で複数選択出来る用に指定)

## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
