### PR TITLE
取り扱いブランドのバリデーションを設定

### DIFF
--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -3,7 +3,7 @@ class Shop < ApplicationRecord
   has_many :shop_images
   has_many :shop_styles, dependent: :destroy, validate: true, inverse_of: :shop
   has_many :styles, through: :shop_styles
-  has_many :shop_brands, dependent: :destroy
+  has_many :shop_brands, dependent: :destroy, validate: true, inverse_of: :shop
   has_many :brands, through: :shop_brands
 
   enum treatment: {male: 0, female: 1, unisex: 2}
@@ -22,7 +22,8 @@ class Shop < ApplicationRecord
   validates :shop_info, presence: true
   validates :shop_info, length: {maximum: 500}, if: Proc.new{|shop|shop.shop_info.present?}
   validates :style_ids, presence: {message: :not_select}
-
+  validates :brand_ids, presence: {message: :not_select}
+  
   # 関連付け先バリデーション
-  validates_associated :shop_styles
+  validates_associated :shop_styles, :shop_brands
 end

--- a/app/models/shop_brand.rb
+++ b/app/models/shop_brand.rb
@@ -1,4 +1,8 @@
 class ShopBrand < ApplicationRecord
   belongs_to :shop
   belongs_to :brand
+
+  # バリデーション
+  validates :shop, presence: true
+  validates :brand_id, uniqueness: {scope: :shop_id}
 end

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -15,6 +15,7 @@ ja:
         sales_info: 定休日・営業情報等
         shop_info: オススメポイント
         style_ids: ショップの系統
+        brand_ids: 取り扱いブランド
       shop/shop_images:
         image: ショップの画像
   enums:


### PR DESCRIPTION
close #62 

## 実装内容

- バリデーションの設定
  - 必須選択
  - 意制約エラー
- エラーメッセージの日本語化
  - ymlファイルに属性の日本語名を追加

## チェックリスト


- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認