### PR TITLE
ショップ一覧画面の処理とビューを実装

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -1,6 +1,7 @@
 class ShopsController < ApplicationController
   before_action :authenticate_user!
   def index
+    @shops = Shop.all
   end
 
   def new

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -2,3 +2,13 @@
   <div class="notice"><%= flash[:success] %></div>
 <% end %>
 <h1 class="text-center">TOP PAGE</h1>
+<% @shops.each do |shop| %>
+  <div>
+    <%= shop.shop_name %>
+    <%= link_to "詳細", shop_path(shop) %>
+    <%= link_to "編集", edit_shop_path(shop) %>
+    <% if shop.user_id == current_user.id %>
+      <%= link_to "削除", shop_path(shop), method: :delete, data: { confirm: '削除します。 よろしいですか?' } %>
+    <% end %>
+  </div>
+<% end %>


### PR DESCRIPTION
close #66 
## 実装内容

- shopsコントローラのindexアクションの処理を実装
- ショップ一覧のビューファイルにショップファイルを出力する
  - ※現時点で出力する情報
    - ショップ名
    - 編集画面へのリンク
    - 詳細画面へのリンク
    - 削除画面へのリンク(投稿者のみ削除可能)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット


## 備考
