### PR TITLE
ショップモデルのルーティングを修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
     <header>
       <% if user_signed_in? %>
         <%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: {confirm: 'ログアウトしますか？'} %>
-        <%= link_to 'ショップ登録', new_user_shop_path(current_user.id) %>
+        <%= link_to 'ショップ登録', new_shop_path %>
       <% else %>
         <%= link_to '新規登録', new_user_registration_path %>
         <%= link_to 'ログイン', new_user_session_path %>

--- a/app/views/shops/new.html.erb
+++ b/app/views/shops/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @shop, url: user_shops_path, local: true do |f| %>
+<%= form_with model: @shop, local: true do |f| %>
   <div class="form-group">
     <p><%= f.label :shop_name %></p>
     <%= f.text_field :shop_name, class: "form-control" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,5 @@ Rails.application.routes.draw do
   devise_for :users
   # トップページ
   root to: 'shops#index'
-  resources :users, only: %W() do
-    resources :shops
-  end
+  resources :shops
 end


### PR DESCRIPTION
close #67 

## 実装内容

- userモデルとshopモデルのネストしたルーティングを修正する
  - shopモデルはネストさせず、`resources`で設定
- ルーティング修正に伴い、リンク先のパスで修正が必要な部分は改修を行う
  - ショップ登録画面へのリンク先のパスを修正
  - 登録時のパラメータ送信先のパスを修正


## チェックリスト


- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 備考
