### PR TITLE
ショップ詳細画面の実装

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -22,6 +22,10 @@ class ShopsController < ApplicationController
     end
   end
 
+  def show
+    @shop = Shop.find(params[:id])
+  end
+
   private
   def shop_params
     params.require(:shop).permit(

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -1,0 +1,59 @@
+<h1>ショップ詳細情報</h1>
+
+<div>
+  <%= Shop.human_attribute_name(:shop_name) %>
+  <%= @shop.shop_name %>
+</div>
+
+<div>
+  <%= Shop.human_attribute_name(:sales_time) %>
+  <%= @shop.open_time.strftime('%H:%M') %> ~ <%= @shop.close_time.strftime('%H:%M') %>
+</div>
+
+<div>
+  <%= Shop.human_attribute_name(:treatment) %>
+  <%= @shop.treatment_i18n %>
+</div>
+
+<div>
+  <%= Shop.human_attribute_name(:tel_number) %>
+  <%= link_to @shop.tel_number, "tel:" + @shop.tel_number %>
+</div>
+
+<div>
+  <%= Shop.human_attribute_name(:site_url) %>
+  <%= @shop.site_url %>
+</div>
+
+<div>
+  <%= Shop.human_attribute_name(:instgram_url) %>
+  <%= @shop.instgram_url %>
+</div>
+
+<div>
+  <%= Shop.human_attribute_name(:sales_info) %>
+  <%= @shop.sales_info %>
+</div>
+
+<div>
+  <%= Shop.human_attribute_name(:shop_info) %>
+  <%= @shop.shop_info %>
+</div>
+
+<div>
+  <%= Shop.human_attribute_name(:style_ids) %>
+  <ul>
+    <% @shop.shop_styles.each do |shop_style| %>
+      <li><%= shop_style.style.taste %></li>
+    <% end %>
+  </ul>
+</div>
+
+<div>
+  <%= Shop.human_attribute_name(:brand_ids) %>
+  <ul>
+    <% @shop.shop_brands.each do |shop_brand| %>
+      <li><%= shop_brand.brand.brand_name %></li>
+    <% end %>
+  </ul>
+</div>

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -8,6 +8,7 @@ ja:
         shop_name: ショップ名
         open_time: 開店時間
         close_time: 閉店時間
+        sales_time: 営業時間
         treatment: 取り扱い
         tel_number: 電話番号
         site_url: WebサイトURL


### PR DESCRIPTION
close #70 

## 実装内容
- コントローラ
  - `show`アクションの実装
- ビュー
  - `show.html.erb`を追加
  - ショップの項目情報のみ出力(デザイン・レイアウト未)
- 翻訳
  - `yml`ファイルに`営業時間`を追加

## 参考資料
- ショップ詳細画面
  - [Railsのi18nによる日本語化対応](https://qiita.com/shimadama/items/7e5c3d75c9a9f51abdd5)

## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## 備考
