### PR TITLE
ショップ削除処理の実装

### DIFF
--- a/app/controllers/shops_controller.rb
+++ b/app/controllers/shops_controller.rb
@@ -26,6 +26,18 @@ class ShopsController < ApplicationController
     @shop = Shop.find(params[:id])
   end
 
+  def destroy
+    shop = Shop.find(params[:id])
+
+    if shop.user_id == current_user.id
+      shop_name = shop.shop_name
+      shop.destroy
+      redirect_to root_path, flash: {success: "#{shop_name}の情報を削除しました"}
+    else
+      redirect_back(fallback_location: root_path, flash: {notice: "投稿ユーザー以外はショップ情報を削除できません"})
+    end
+  end
+
   private
   def shop_params
     params.require(:shop).permit(

--- a/app/views/shops/index.html.erb
+++ b/app/views/shops/index.html.erb
@@ -1,7 +1,11 @@
-<% if flash[:success] %>
-  <div class="notice"><%= flash[:success] %></div>
-<% end %>
 <h1 class="text-center">TOP PAGE</h1>
+
+<% if flash[:success] %>
+  <div class="success"><%= flash[:success] %></div>
+<% elsif flash[:notice] %>
+  <div class="notice"><%= flash[:notice] %></div>
+<% end %>
+
 <% @shops.each do |shop| %>
   <div>
     <%= shop.shop_name %>


### PR DESCRIPTION
close #72
## 実装内容

- コントローラ
  - `destroy`アクションの実装
- ビュー
  - 削除ボタンの追加
  - フラッシュメッセージを出力できるよに追加

## 参考資料
- リダイレクト処理
  - [redirect_backの使い方 ](https://hitsuji-mon.hatenablog.com/entry/2019/08/31/185834)
  - [git hub redirect_back](https://github.com/rails/rails/blob/f33d52c95217212cbacc8d5e44b5a8e3cdc6f5b3/actionpack/lib/action_controller/metal/redirecting.rb#L90)

## チェックリスト


- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット


## 備考
