### PR TITLE
レビュー編集処理の追加

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -5,7 +5,6 @@ class ReviewsController < ApplicationController
   end
 
   def create
-    binding.pry
     @review = current_user.reviews.build(review_params)
     @review.shop_id = params[:shop_id]
     if @review.save
@@ -13,6 +12,21 @@ class ReviewsController < ApplicationController
     else
       @shop = Shop.find(params[:shop_id])
       render 'reviews/new'
+    end
+  end
+
+  def edit
+    @shop = Shop.find(params[:shop_id])
+    @review = Review.find(params[:id])
+  end
+
+  def update
+    @review = Review.find(params[:id])
+    if @review.update(review_params)
+      redirect_to shop_path(@review.shop_id), flash: {success: "#{Shop.find(@review.shop_id).shop_name}のレビューを更新しました"}
+    else
+      @shop = Shop.find(params[:shop_id])
+      render 'reviews/edit'
     end
   end
 

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -5,4 +5,7 @@ class Review < ApplicationRecord
   validates :title, :rate, :content, presence: true
   validates :title, length: {maximum: 50}, if: Proc.new{|review|review.title.present?}
   validates :content, length: {maximum: 1000}, if: Proc.new{|review|review.content.present?}
+  validates :shop, presence: true
+  validates :user, presence: true
+  validates :user_id, uniqueness: {scope: :shop_id}, if: Proc.new{|review|review.title.present? && review.rate.present? && review.content.present?}
 end

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,0 +1,26 @@
+
+
+<%= form_with model: [shop, review], url: action_path, local: true do |f| %>
+  <div class="form-group">
+    <p><%= f.label :title %></p>
+    <%= f.text_field :title, class:"form-control" %>
+    <%= render partial: 'error_msg', locals: {review: review, param_name: 'title'} %>
+  </div>
+
+  <div class="form-group" id="star">
+      <p><%= f.label :rate%></p>
+      <%= f.hidden_field :rate, id: :review_star %>
+  </div>
+  <div>
+    <%= render partial: 'error_msg', locals: {review: review, param_name: 'rate'} %>
+  </div>
+
+
+  <div class="form-group">
+    <p><%= f.label :content %></p>
+    <%= f.text_area :content, class:"form-control" %>
+    <%= render partial: 'error_msg', locals: {review: review, param_name: 'content'}%>
+  </div>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,0 +1,17 @@
+<h1>レビュー編集</h1>
+
+
+<%= render partial: 'form', locals: {shop: @shop, review: @review, action_path: shop_review_path } %>
+
+<script>
+  $('#star').raty({
+    size     : 33,
+    starOff:  '<%= asset_path('star-off.png') %>',
+    starHalf : '<%= asset_path('star-half.png') %>',
+    starOn : '<%= asset_path('star-on.png') %>',
+
+    scoreName: 'review[rate]]',
+    score: <%= @review.rate %>,
+    half: true,
+  });
+</script>  

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -1,30 +1,11 @@
 <h1>レビュー投稿</h1>
-
-<%= form_with model: [@shop, @review], url: shop_reviews_path, local: true do |f| %>
-  <div class="form-group">
-    <p><%= f.label :title %></p>
-    <%= f.text_field :title, class:"form-control" %>
-    <%= render partial: 'error_msg', locals: {review: @review, param_name: 'title'} %>
-  </div>
-
-  <div class="form-group" id="star">
-      <p><%= f.label :rate%></p>
-      <%= f.hidden_field :rate, id: :review_star %>
-  </div>
-  <div>
-    <%= render partial: 'error_msg', locals: {review: @review, param_name: 'rate'} %>
-  </div>
-
-
-  <div class="form-group">
-    <p><%= f.label :content %></p>
-    <%= f.text_area :content, class:"form-control" %>
-    <%= render partial: 'error_msg', locals: {review: @review, param_name: 'content'}%>
-  </div>
-
-  <%= f.submit %>
+<% if @review.errors[:user_id] %>
+  <% @review.errors[:user_id].each do |message| %>
+    <li><%= Review.human_attribute_name(:user_id) + message %></li>
+  <% end %>
 <% end %>
 
+<%= render partial: 'form', locals: {shop: @shop, review: @review, action_path: shop_reviews_path } %>
 <script>
   $('#star').raty({
     size     : 33,
@@ -35,4 +16,4 @@
     scoreName: 'review[rate]]',
     half: true,
   });
-  </script>  
+</script>  

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -63,4 +63,5 @@
 <hr>
 <% @shop.reviews.each do |review| %>
   <%= review.title %>
+  <%= link_to '編集', edit_shop_review_path(@shop ,review) %>
 <% end %>


### PR DESCRIPTION
close #87

## 実装内容

- レビューモデル編集処理を実装する
  - コントローラ
    - `edit`,`update`アクションの実装
- ショップ詳細画面へ、レビュー編集画面へのリンクを追加
- ビュー
  - ショップ詳細画面にレビューの内容を出力  
  - 登録フォームのテンプレート化
  - レビュー編集画面の実装

## 参考資料

## チェックリスト


- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット


## 備考
