### PR TITLE
お気に入りショップモデルの実装

### DIFF
--- a/app/models/like_shop.rb
+++ b/app/models/like_shop.rb
@@ -1,4 +1,4 @@
 class LikeShop < ApplicationRecord
   belongs_to :user
-  belongs_to :shop
+  belongs_to :shop, :counter_cache => true
 end

--- a/app/models/like_shop.rb
+++ b/app/models/like_shop.rb
@@ -1,0 +1,4 @@
+class LikeShop < ApplicationRecord
+  belongs_to :user
+  belongs_to :shop
+end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -7,6 +7,7 @@ class Shop < ApplicationRecord
   has_many :shop_brands, dependent: :destroy, validate: true, inverse_of: :shop
   has_many :brands, through: :shop_brands
   has_many :reviews
+  has_many :like_shops
 
   enum treatment: {male: 0, female: 1, unisex: 2}
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   has_many :shops
   has_many :reviews
+  has_many :like_shops
 end

--- a/db/migrate/20210211102644_create_like_shops.rb
+++ b/db/migrate/20210211102644_create_like_shops.rb
@@ -1,0 +1,11 @@
+class CreateLikeShops < ActiveRecord::Migration[6.0]
+  def change
+    create_table :like_shops do |t|
+      t.references :shop, null: false, foreign_key: true, index: false, comment: "ショップID"
+      t.references :user, null: false, foreign_key: true, index: false, comment: "ユーザーID"
+
+      t.timestamps
+    end
+    add_index :like_shops, %W(shop_id user_id), unique: true
+  end
+end

--- a/db/migrate/20210211102644_create_like_shops.rb
+++ b/db/migrate/20210211102644_create_like_shops.rb
@@ -3,6 +3,7 @@ class CreateLikeShops < ActiveRecord::Migration[6.0]
     create_table :like_shops do |t|
       t.references :shop, null: false, foreign_key: true, index: false, comment: "ショップID"
       t.references :user, null: false, foreign_key: true, index: false, comment: "ユーザーID"
+      t.integer :likes_count, null: false, default: 0, comment: "お気に入り数"
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_102644) do
   create_table "like_shops", force: :cascade do |t|
     t.bigint "shop_id", null: false, comment: "ショップID"
     t.bigint "user_id", null: false, comment: "ユーザーID"
+    t.integer "likes_count", default: 0, null: false, comment: "お気に入り数"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["shop_id", "user_id"], name: "index_like_shops_on_shop_id_and_user_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_07_045317) do
+ActiveRecord::Schema.define(version: 2021_02_11_102644) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,14 @@ ActiveRecord::Schema.define(version: 2021_02_07_045317) do
     t.string "brand_name_kana", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "like_shops", force: :cascade do |t|
+    t.bigint "shop_id", null: false, comment: "ショップID"
+    t.bigint "user_id", null: false, comment: "ユーザーID"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["shop_id", "user_id"], name: "index_like_shops_on_shop_id_and_user_id", unique: true
   end
 
   create_table "reviews", force: :cascade do |t|
@@ -117,6 +125,8 @@ ActiveRecord::Schema.define(version: 2021_02_07_045317) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "like_shops", "shops"
+  add_foreign_key "like_shops", "users"
   add_foreign_key "reviews", "shops"
   add_foreign_key "reviews", "users"
   add_foreign_key "shop_brands", "brands"


### PR DESCRIPTION
close #95 

## 実装内容
- お気に入りモデルの実装
- 親モデル(ショップ、ユーザー)モデルとの関連付け
- カウンターキャッシュの設定

  ## 設計書
[DB 設計書](https://docs.google.com/spreadsheets/d/1a0YhdVtr8mX5blABDtOSthhT1XV3JU4XNchhfDeQoT0/edit#gid=2120403934)

## チェックリスト


- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット


## 備考
