### PR TITLE
コントローラの命名を修正

### DIFF
--- a/app/controllers/like_shops_controller.rb
+++ b/app/controllers/like_shops_controller.rb
@@ -1,6 +1,7 @@
-class LikeShopController < ApplicationController
+class LikeShopsController < ApplicationController
   before_action :set_shop
   def create
+    binding.pry
     current_user.like_shops.create(shop_id: @shop.id)
   end
 


### PR DESCRIPTION
close #100 


## 修正内容
- ファイル名の修正
  -  コントローラのファイル名が単数形になっているため、複数系に修正
  - `like_shop_controller.rb` ⇛ `like_shops_controller.rb`
- クラス名の修正
  - 上記と同様にクラス名が単数形になっているため、複数系に修正
  - `LikeShopController` ⇛ `LikeShopsController`

## チェックリスト


- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット


## 備考
