### PR TITLE
お気に入りショップモデルとショップモデルのカラム修正

### DIFF
--- a/app/models/like_shop.rb
+++ b/app/models/like_shop.rb
@@ -1,4 +1,4 @@
 class LikeShop < ApplicationRecord
   belongs_to :user
-  belongs_to :shop, :counter_cache => true
+  belongs_to :shop, counter_cache: :likes_count
 end

--- a/db/migrate/20210212063845_remove_like_count_from_like_shops.rb
+++ b/db/migrate/20210212063845_remove_like_count_from_like_shops.rb
@@ -1,0 +1,5 @@
+class RemoveLikeCountFromLikeShops < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :like_shops, :likes_count, :integer
+  end
+end

--- a/db/migrate/20210212064016_add_like_count_to_shops.rb
+++ b/db/migrate/20210212064016_add_like_count_to_shops.rb
@@ -1,0 +1,5 @@
+class AddLikeCountToShops < ActiveRecord::Migration[6.0]
+  def change
+    add_column :shops, :likes_count, :integer, null: false, default: 0, comment: "お気に入り数"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_11_102644) do
+ActiveRecord::Schema.define(version: 2021_02_12_064016) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,7 +51,6 @@ ActiveRecord::Schema.define(version: 2021_02_11_102644) do
   create_table "like_shops", force: :cascade do |t|
     t.bigint "shop_id", null: false, comment: "ショップID"
     t.bigint "user_id", null: false, comment: "ユーザーID"
-    t.integer "likes_count", default: 0, null: false, comment: "お気に入り数"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["shop_id", "user_id"], name: "index_like_shops_on_shop_id_and_user_id", unique: true
@@ -105,6 +104,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_102644) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "treatment", null: false, comment: "取り扱い"
+    t.integer "likes_count", default: 0, null: false, comment: "お気に入り数"
     t.index ["user_id"], name: "index_shops_on_user_id"
   end
 


### PR DESCRIPTION
close #101 
## 修正内容
- モデル
  - `like_shop`モデルから、`likes_coint`カラムを削除する。その後マイグレーションを再度実行
  - `shop`モデルに`likes_count`カラムを追加する。
  - `counter_cache`の設定を再度行う  

## チェックリスト


- [x] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認